### PR TITLE
#156008359 Enable sharing of the displayed user profiles

### DIFF
--- a/app/src/main/java/com/example/javacodersnairobi/DetailActivity.java
+++ b/app/src/main/java/com/example/javacodersnairobi/DetailActivity.java
@@ -1,9 +1,11 @@
 package com.example.javacodersnairobi;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -25,6 +27,8 @@ public class DetailActivity extends AppCompatActivity implements SingleProfileVi
     @Override
     public void displayProfile(GithubUsers profile) {
         View view = findViewById(R.id.detail_layout);
+        final String profileUrl = profile.getProfileUrl();
+        final String githubHandle = profile.getUsername();
 
         // Obtain references to views on the profile details page
         ImageView profileImage = view.findViewById(R.id.profile_image);
@@ -33,6 +37,7 @@ public class DetailActivity extends AppCompatActivity implements SingleProfileVi
         TextView repos = view.findViewById(R.id.repos);
         TextView followers = view.findViewById(R.id.followers);
         TextView following = view.findViewById(R.id.following);
+        Button shareButton = view.findViewById(R.id.button);
 
         // Assign values to the referenced views
         Picasso.with(this).load(profile.getAvatar()).into(profileImage);
@@ -41,6 +46,17 @@ public class DetailActivity extends AppCompatActivity implements SingleProfileVi
         repos.setText(profile.getRepos());
         followers.setText(profile.getFollowers());
         following.setText(profile.getFollowing());
+        shareButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(Intent.ACTION_SEND);
+                intent.setType("text/plain");
+                String shareMessage = "Checkout this awesome developer @" + githubHandle + ", " +
+                        profileUrl + ".";
+                intent.putExtra(Intent.EXTRA_TEXT, shareMessage);
+                startActivity(Intent.createChooser(intent, "Share Github profile with:"));
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/example/javacodersnairobi/model/GithubUsers.java
+++ b/app/src/main/java/com/example/javacodersnairobi/model/GithubUsers.java
@@ -18,6 +18,9 @@ public class GithubUsers {
 
     String following;
 
+    @SerializedName("html_url")
+    String profile;
+
     public String getAvatar() {
         return avatar;
     }
@@ -40,5 +43,9 @@ public class GithubUsers {
 
     public String getFollowing() {
         return following;
+    }
+
+    public String getProfileUrl() {
+        return profile;
     }
 }


### PR DESCRIPTION
### What does this PR do?
Enables users to share the GitHub profiles of the displayed users
#### Description of the task to be completed?
- Attach an on-click listener to the share button in DetailActivity.java
- Update GithubUsers.java to obtain a user's profile URL
#### How should this be manually tested?
- Run the project in Android Studio and select a single profile on the homepage
- Tap on the share button and select an option to share
- Verify that the sharing has been done
#### Screenshots
![Share Profile](https://user-images.githubusercontent.com/34346070/54533957-6a615400-499c-11e9-8e05-1a7020c68763.gif)
#### What are the relevant Pivotal Tracker stories?
[#156008359](https://www.pivotaltracker.com/story/show/156008359)